### PR TITLE
fix: Add Cloudflare Pages redirects for SEO trailing slash issues

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,14 @@
+# Cloudflare Pages Redirects Configuration
+# Fix SEO duplicate content issues by redirecting non-trailing slash URLs to trailing slash versions
+
+# Redirect all non-trailing slash URLs to trailing slash with 301 (permanent redirect)
+# This ensures search engines see only one canonical version of each page
+/:slug /:slug/ 301!
+
+# Handle specific edge cases
+# Root domain without trailing slash to with trailing slash
+https://ride-more.org https://ride-more.org/ 301!
+http://ride-more.org https://ride-more.org/ 301!
+
+# Ensure HTTPS redirect while handling trailing slash
+http://:domain/:path https://:domain/:path/ 301!


### PR DESCRIPTION
## 🔧 SEO Fix: Trailing Slash Redirects

This PR addresses the duplicate URL issue identified in #5 by implementing proper redirects using Cloudflare Pages' `_redirects` file.

### 🐛 Problem
Search engines were discovering both versions of URLs:
- `https://ride-more.org/` (with trailing slash)
- `https://ride-more.org` (without trailing slash)

This creates **duplicate content issues** that can harm SEO rankings.

### ✅ Solution
Added `static/_redirects` file with redirect rules:

```
# Redirect non-trailing slash URLs to trailing slash versions
/:slug /:slug/ 301!

# Handle root domain specifically  
https://ride-more.org https://ride-more.org/ 301!
http://ride-more.org https://ride-more.org/ 301!

# Ensure HTTPS while handling trailing slash
http://:domain/:path https://:domain/:path/ 301!
```

### 🎯 Benefits
- **Canonical URLs**: Only one version of each URL is accessible
- **Better SEO**: Prevents duplicate content penalties
- **301 Redirects**: Preserves link equity and tells search engines the redirect is permanent
- **HTTPS Enforcement**: Ensures secure connections
- **Future-proof**: Works for all current and future pages

### 🧪 Testing
After deployment, you can test with:
```bash
curl -I https://ride-more.org  # Should redirect to https://ride-more.org/
```

### 🔗 Related
Fixes #5

---

This implements the exact solution recommended in the issue and follows Cloudflare Pages best practices for SEO-friendly redirects."