### PR TITLE
docs: add founding phase context and set realistic expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The MORE Club Resource Center is an active community project in its founding pha
 
 **Want to be part of building this community?** We welcome founding members who want to help shape our club culture, event programming, and riding community. Your input and participation in this early stage will directly influence what the MORE Club becomes.
 
-[Join our Discord](/discord) | [Contact us](mailto:more@ride-more.org) to get involved
+[Join our Discord](https://ride-more.org/discord) | [Contact us](mailto:more@ride-more.org) to get involved
  
 ## 🚀 Quick Start for Contributors
 

--- a/README.md
+++ b/README.md
@@ -17,119 +17,65 @@ Welcome to the **MORE Club Resource Center** - your comprehensive guide to off-r
 - **Trail Information** - Local trail systems, maps, and current conditions  
 - **Riding Styles Guide** - Comprehensive guide to different motorcycle types and riding styles
 - **Community Resources** - Connect with fellow riders and join group rides 
+
+## 📍 Current Organizational Status
+
+The MORE Club Resource Center is an active community project in its founding phase:
+
+✅ **Live Now:**
+- Comprehensive safety and trail resources
+- Community Discord for rider connection
+- Open-source contribution model
+- Professional documentation and website
+
+🚧 **In Development:**
+- Regular organized ride schedule
+- Formal membership structure
+- Partner benefit programs
+- Established event calendar
+
+**Want to be part of building this community?** We welcome founding members who want to help shape our club culture, event programming, and riding community. Your input and participation in this early stage will directly influence what the MORE Club becomes.
+
+[Join our Discord](/discord) | [Contact us](mailto:more@ride-more.org) to get involved
  
 ## 🚀 Quick Start for Contributors
 
-### Prerequisites
-
-This project uses [Yarn 4](https://yarnpkg.com/) for dependency management.
-
-- **Node.js 22+** (we test with Node.js 22.x to match our deployment environment)
-- **Yarn 4.13.0** (managed via Corepack, included with Node.js)
-- **Git** for version control
-
-### Installation
+Want to contribute? Great! Here's the fastest way to get started:
 
 ```bash
-# Clone the repository
-git clone https://github.com/bcdady/ride-more-org.git
+# Fork and clone the repository
+git clone https://github.com/YOUR_USERNAME/ride-more-org.git
 cd ride-more-org
 
-# Install dependencies
-yarn install
-
-# Enable Corepack if not already enabled
+# Install dependencies and start development server
 corepack enable
-```
-
-### Local Development
-
-```bash
-# Start development server
+yarn install
 yarn start
 ```
 
-This starts a local development server at `http://localhost:3000` with hot reloading. Most changes are reflected live without restarting the server.
+Your local site will be running at `http://localhost:3000` with hot reloading.
 
-### Building for Production
-
-```bash
-# Build static site
-yarn build
-
-# Serve locally to test
-yarn serve
-```
-
-### Code Quality & Testing
-
-```bash
-# Type checking
-yarn typecheck
-
-# Linting (if configured)
-yarn lint
-
-# Format code (if configured)
-yarn format
-```
+**📖 For complete details** including setup, workflows, guidelines, and DCO requirements, see **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
 ## 📝 Contributing
 
-We welcome contributions! Please follow these guidelines:
+We welcome contributions of all types - content, code, design, or ideas! Whether you're:
+- 📝 Improving safety documentation or trail information
+- 💻 Fixing bugs or adding features
+- 🎨 Enhancing design or user experience
+- 🐛 Reporting issues or suggesting improvements
 
-### 🔄 Development Workflow
+**Please read our [Contributing Guide](CONTRIBUTING.md)** for:
+- Development workflow and setup instructions
+- Content and code guidelines
+- Pull request process and DCO requirements
+- Community guidelines and getting help
 
-1. **Fork** the repository
-2. **Create a feature branch**: `git checkout -b feature/amazing-feature`
-3. **Make your changes** and test locally
-4. **Commit with DCO sign-off**: `git commit -s -m "feat: add amazing feature"`
-5. **Push** your branch: `git push origin feature/amazing-feature`
-6. **Create a Pull Request** with a clear description
-
-### ✅ Pull Request Requirements
-
-Our automated CI pipeline will check:
-
-- ✅ **Build success** - Your changes build without errors
-- ✅ **Code quality** - ESLint and Prettier formatting
-- ✅ **Security** - Dependency vulnerabilities and code security
-- ✅ **DCO compliance** - All commits must be signed off
-
-### 📁 Project Structure
-
-```
-ride-more-org/
-├── docs/                 # Main documentation content
-│   ├── intro.md         # Club resources overview
-│   ├── safety.md        # Safety guidelines
-│   ├── trails.md        # Trail information
-│   └── styles.md        # Motorcycle types & styles
-├── blog/                # Blog posts and updates
-├── src/                 # Custom React components
-├── static/              # Static assets (images, files)
-├── .github/             # GitHub workflows and automation
-└── docusaurus.config.js # Site configuration
-```
-
-### 🎨 Content Guidelines
-
-**Writing Style:**
-- Use clear, accessible language
-- Focus on safety and practical information
-- Include relevant examples and tips
-
-**Safety Content:**
-- Always emphasize safety first
-- Provide actionable, specific guidance
-- Include emergency procedures where relevant
-
-**Technical Content:**
-- Keep explanations beginner-friendly
-- Use bullet points for easy scanning
-- Include links to authoritative sources
+**Important:** All commits must be signed off with DCO using `git commit -s`
 
 ## 🛠️ Technical Details
+
+
 
 **Built With:**
 - [Docusaurus 3](https://docusaurus.io/) - Static site generator
@@ -154,6 +100,12 @@ ride-more-org/
 - **Discord:** [Join our community](/discord) for real-time discussions
 - **Issues:** [Report bugs or request features](https://github.com/bcdady/ride-more-org/issues)
 - **Email:** [more@ride-more.org](mailto:more@ride-more.org) for general inquiries
+
+### Community Guidelines
+
+- **[Code of Conduct](CODE_OF_CONDUCT.md)** - Our commitment to a safe, inclusive community
+- **[Contributing Guide](CONTRIBUTING.md)** - How to contribute content, code, or ideas
+- **[Governance](GOVERNANCE.md)** - How decisions are made and how to get involved
 
 ## 📄 License
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -4,6 +4,8 @@ sidebar_position: 1
 
 # Club Resources
 
+> **🚧 Founding Phase:** We're actively building these resources together! As a founding member, you can help shape what information and guides would be most valuable. Join our Discord community to contribute ideas and help develop the content you want to see.
+
 Welcome to the **MORE Club Resource Center**! Here you'll find essential information for safe and enjoyable off-road motorcycle adventures.
 
 ## What You'll Find Here

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -1,16 +1,18 @@
 # About Motorcycle Off-Road Explorers
 
+> **🚧 Founding Phase:** The MORE Club is actively building our community and establishing regular programming. We're seeking founding members to help shape our club culture, event schedule, and riding programs. Join us in creating something special!
+
 ## Our Mission
 
-The Motorcycle Off-Road Explorers (MORE) club brings together riders who share a passion for motorcycle adventures. We explore beautiful trails and backcountry routes while building a strong, supportive community of new and experienced riders.
+The Motorcycle Off-Road Explorers (MORE) club brings together riders who share a passion for motorcycle adventures. We're building a community to explore beautiful trails and backcountry routes while supporting new and experienced riders alike.
 
-## What We Do
+## What We're Building
 
-- **Group Rides**: We organize regular group rides to explore new trails and revisit favorite destinations
-- **Skill Building**: We host workshops and training sessions to improve riding techniques and safety
-- **Trail Maintenance**: We give back to the riding community by participating in trail maintenance projects
-- **Social Events**: We build camaraderie through club meetings, BBQs, and social gatherings
-- **Adventure Planning**: We plan multi-day expeditions and epic adventure rides
+- **Group Rides**: We're establishing regular group rides to explore new trails and favorite destinations
+- **Skill Building**: We're planning workshops and training sessions to improve riding techniques and safety
+- **Trail Maintenance**: We'll give back to the riding community by participating in trail maintenance projects
+- **Social Events**: We're organizing club meetings, BBQs, and social gatherings to build camaraderie
+- **Adventure Planning**: We're developing multi-day expeditions and epic adventure rides
 
 ## Our Values
 
@@ -30,17 +32,21 @@ We ride responsibly and respect the environment, following Leave No Trace princi
 
 Safety is paramount in everything we do. We promote proper gear, riding techniques, and emergency preparedness.
 
-## Join Us
+## Join Us as a Founding Member
 
-Whether you're a seasoned off-road veteran or just getting started, the MORE club welcomes you! Our members ride all types of bikes and bring varying experience levels. What matters most is your enthusiasm for adventure and respect for our community.
+Whether you're a seasoned off-road veteran or just getting started, the MORE club welcomes you! We're looking for riders of all types and experience levels who want to help build this community. What matters most is your enthusiasm for adventure, respect for our community, and interest in shaping what the MORE Club becomes.
 
-### Membership Benefits
+### Founding Member Opportunities
 
-- Access to club rides and events
-- Skills workshops and training opportunities
-- Trail maps and route sharing
-- Equipment discounts through club partnerships
-- Emergency support network
-- Lifelong friendships
+As we establish the MORE Club, founding members will help shape:
 
-Ready to join the adventure? [Contact us](/contact) to learn more about membership!
+- **Club rides and event calendar** - Decide when, where, and how often we ride
+- **Skills workshops and training format** - Define what skills to focus on
+- **Trail maps and route sharing** - Contribute local knowledge and favorite routes
+- **Community partnerships** - Help establish equipment discounts and local business relationships
+- **Emergency support protocols** - Develop our safety and support systems
+- **Lifelong friendships** - Be part of the core community from day one
+
+**Current Status:** We're assembling our founding member group and connecting riders through our Discord community. Early participants will have significant influence in establishing club culture, programs, and traditions.
+
+Ready to help build something special? [Contact us](/contact) or [join our Discord](/discord) to get involved!

--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -20,10 +20,10 @@ Whether you're interested in joining the club, have questions about upcoming eve
 
 ### Monthly Club Meetings
 
-**When**: TBD  
-**Location**: TBD -- We're interested in feedback on preferred locations, including virtual options
+**When**: To be established based on founding member input  
+**Location**: To be determined collaboratively with founding members -- we welcome feedback on preferred locations, including virtual options
 
-**What we cover:**
+**What we'll cover:**
 
 - Upcoming rides and events
 - Club business and announcements  
@@ -57,6 +57,6 @@ We value your input! [Contact us](mailto:more@ride-more.org?subject=MORE%20Club%
 - Partnership opportunities
 - General club feedback
 
-**Response Time**: We typically respond to emails within 2-3 business days. For urgent matters, please indicate in your subject line.
+**Response Time**: We're a volunteer-run organization in our founding phase. We'll do our best to respond within 3-5 business days. Thank you for your patience as we build our community! For urgent matters, please indicate in your subject line.
 
 Thank you for visiting, and we look forward to connecting with you!

--- a/src/pages/discord.md
+++ b/src/pages/discord.md
@@ -4,6 +4,8 @@ title: Join Our Discord Community | MORE Club
 
 # Join the MORE Missoula Discord Community
 
+> **🚧 Founding Phase:** Our Discord community is where the MORE Club is actively building! Join us to connect with fellow riders, help plan our first rides and events, and be part of shaping what this club becomes. As a founding member, you'll have direct input into our community culture and programming.
+
 ## What is Discord?
 
 Discord is a free communication platform that offers text chat channels and other community collaboration features. Think of it as a modern forum mixed with instant messaging - perfect for our riding community to stay connected between rides!
@@ -47,6 +49,8 @@ Discord is a free communication platform that offers text chat channels and othe
 ## Server Channels Overview
 
 Our MORE Missoula Discord is organized into different channels for different purposes:
+
+**Note:** As we're in our founding phase, our channel structure may evolve based on member needs and feedback. We'll adjust channels as we learn what works best for our community.
 
 ### 📢 Information Channels
 

--- a/src/pages/events.md
+++ b/src/pages/events.md
@@ -1,24 +1,26 @@
 # Upcoming Events
 
+> **🚧 Founding Phase Notice:** The MORE Club is establishing its event calendar. The schedule below represents our planned programming as we build our community. Actual dates will be announced as we confirm ride leaders and participant interest. [Join our Discord](/discord) or [contact us](mailto:more@ride-more.org) for current activity updates and to help us launch our first official events!
+
 *Missoula, Montana Chapter*
 
 ## Weekly Club Rides (Seasonal)
 
 ### Saturday Trail Exploration
 
-**When**: Every 2nd Saturday (April - October)  
+**When**: Planned for every 2nd Saturday (April - October) once launched  
 **Time**: 9:00 AM - 4:00 PM  
 **Meeting Point**: Missoula area (location varies by ride)  
 **Skill Level**: All levels welcome  
-**Description**: Join us for a day of trail exploration in the beautiful mountains surrounding Missoula! We'll discover new routes and enjoy the camaraderie of fellow riders. Routes vary from beginner-friendly forest roads to challenging single-track trails in the Bitterroot and Cabinet Mountains.
+**Description**: We're planning a day of trail exploration in the beautiful mountains surrounding Missoula! We'll discover new routes and enjoy the camaraderie of fellow riders. Routes will vary from beginner-friendly forest roads to challenging single-track trails in the Bitterroot and Cabinet Mountains.
 
 ### Sunday Skills Workshop  
 
-**When**: Every 3rd Sunday (May - September)  
+**When**: Planned for every 3rd Sunday (May - September) once launched  
 **Time**: 10:00 AM - 2:00 PM  
 **Location**: Practice areas near Missoula  
 **Skill Level**: Beginner to Intermediate  
-**Description**: Improve your riding technique with hands-on workshops covering cornering, climbing, descending, and emergency maneuvers. These sessions are perfect for building confidence before tackling Montana's more challenging terrain.
+**Description**: We're planning hands-on workshops covering cornering, climbing, descending, and emergency maneuvers. These sessions will be perfect for building confidence before tackling Montana's more challenging terrain.
 
 ## Special Events
 
@@ -27,38 +29,38 @@
 **Date**: TBA - June 2025  
 **Duration**: 3 Days / 2 Nights  
 **Location**: Montana backcountry (camping required)  
-**Description**: Our biggest event of the year! Join us for a multi-day camping and riding adventure exploring Montana's pristine wilderness areas. The rally includes guided trail rides, group meals around the campfire, and evening entertainment under Big Sky country stars.
+**Description**: We're planning our biggest event of the year! This multi-day camping and riding adventure will explore Montana's pristine wilderness areas. The rally will include guided trail rides, group meals around the campfire, and evening entertainment under Big Sky country stars.
 
 ### Trail Maintenance Day
 
 **Date**: TBA - September 2025  
 **Time**: 8:00 AM - 3:00 PM  
 **Location**: Local trail systems around Missoula  
-**Description**: Give back to the trails we love! Join us for trail maintenance work in coordination with the Forest Service. Activities include trail clearing, bridge repair, and signage updates. Tools are provided—just bring work gloves and enthusiasm for preserving Montana's riding opportunities.
+**Description**: Give back to the trails we love! We're planning trail maintenance work in coordination with the Forest Service. Activities will include trail clearing, bridge repair, and signage updates. Tools will be provided—just bring work gloves and enthusiasm for preserving Montana's riding opportunities.
 
 ### New Rider Orientation
 
 **Date**: TBA - Spring 2025  
 **Time**: 6:00 PM - 8:00 PM  
 **Location**: Missoula area meetup location  
-**Description**: Perfect for prospective members! Learn about the club, meet other riders, and get oriented to our riding philosophy and safety practices. We'll cover local trail systems, seasonal riding conditions, and Montana-specific riding considerations.
+**Description**: Perfect for prospective members! We're planning an orientation to learn about the club, meet other riders, and get oriented to our riding philosophy and safety practices. We'll cover local trail systems, seasonal riding conditions, and Montana-specific riding considerations.
 
 ## Regular Meetups
 
 ### Monthly Club Meeting
 
-**When**: First Wednesday of each month (year-round)  
+**When**: Planned for first Wednesday of each month (year-round) once established  
 **Time**: 7:00 PM - 9:00 PM  
 **Location**: Missoula area venue (details in newsletter)  
-**Description**: Plan upcoming rides, discuss club business, and socialize with fellow members. Winter meetings focus on planning, maintenance workshops, and social activities to keep the community connected during the off-season.
+**Description**: We're planning regular meetings to plan upcoming rides, discuss club business, and socialize with fellow members. Winter meetings will focus on planning, maintenance workshops, and social activities to keep the community connected during the off-season.
 
 ## Event Calendar
 
 *Calendar integration coming soon! For now, check our [news blog](/blog) for the latest event announcements and updates.*
 
-## Want to Suggest an Event?
+## Want to Help Launch Our Events?
 
-Have an idea for a club ride or event? We'd love to hear from you! [Contact us](mailto:more@ride-more.org?subject=Event%20Suggestion) with your suggestions.
+Have an idea for a club ride or event? Better yet, want to help organize and lead it? We're actively seeking volunteer ride leaders and event coordinators to help establish our regular programming. [Contact us](mailto:more@ride-more.org?subject=Event%20Organization) to get involved in bringing these events to life!
 
 ## Event Guidelines
 

--- a/src/pages/members.md
+++ b/src/pages/members.md
@@ -1,28 +1,38 @@
 # Membership
 
+> **🚧 Founding Phase:** We're in the early stages of building the MORE Club! As a founding member, you'll have a unique opportunity to shape what this club becomes. Rather than joining an established club with set programs, you'll help us build the ride calendar, establish our community culture, and create the activities and events that matter most to our members.
+
 ## Join the Adventure
 
 The Motorcycle Off-Road Explorers club welcomes riders of all skill levels who appreciate that we can go farther together. Whether you're just starting out or you're a seasoned veteran, there's a place for you in our community.
 
-## Community Membership Benefits
+## Founding Member Opportunities
 
-### 🏍️ **Group Rides & Events**
+As a founding member, you won't just receive benefits—you'll help **build** them! Here's what you can help create:
 
-- Access to organized rides and guided introductions to new trails
-- Annual adventure rally participation
-- Skills workshops and training sessions
-- Special events and social gatherings
-- Trail maintenance days and volunteer opportunities
-- Real-world gear recommendations and conversations
-- Ride buddy matching service
+### 🏍️ **Shape Our Ride Program**
 
+- **Plan our first group rides** - Suggest trails, help scout routes, and organize inaugural rides
+- **Design our event calendar** - What kinds of rides and events do you want to see?
+- **Develop skills workshops** - Share your expertise or help identify instructors
+- **Create social gatherings** - Help plan our first meetups and celebrations
+- **Establish trail maintenance traditions** - Build our community service culture from day one
+- **Build our trail database** - Document and share your favorite riding spots
 
-### 🤝 **Community**
+### 🤝 **Build Our Community Culture**
 
-- Monthly social meetups
-- Online forums and messaging
-- Mentorship program for new riders
-- Lifelong friendships and connections
+- **Define how we communicate** - Help set the tone in our Discord channels
+- **Create mentorship connections** - Be among the first to welcome new riders
+- **Establish club traditions** - What makes our club unique?
+- **Shape our values** - Help determine what matters most to us as a community
+- **Form lasting friendships** - Connect with the core group building this from scratch
+
+### 🎯 **Direct Input & Influence**
+
+- **Voice in decision-making** - Your ideas matter as we establish club structure
+- **Leadership opportunities** - Take on roles that interest you early on
+- **Set the standard** - Be part of the group that defines what MORE Club is all about
+- **Build something meaningful** - Don't just join a club—help create one
 
 
 ## Member Spotlights

--- a/src/pages/rides.md
+++ b/src/pages/rides.md
@@ -1,6 +1,8 @@
 # Ride Reports & Adventures
 
-## Featured Rides
+> **🚧 Founding Phase:** We're actively building our ride calendar and trail database! These are example rides to show what we're planning. Join our [Discord community](/discord) to help plan our first rides, suggest trails you love, and shape our riding program. Your input as a founding member will directly influence what rides we organize and how we explore together.
+
+## Featured Rides (Planned Examples)
 
 ### Schwartz Creek Loop
 


### PR DESCRIPTION
This update transforms our documentation to transparently reflect that the MORE Club is in its founding phase while maintaining enthusiasm and inviting participation.

Major changes:
- Add 'Current Organizational Status' section to README
- Add founding phase notices to all public-facing pages
- Replace 'membership benefits' with 'founding member opportunities'
- Change present tense claims to future/planning language
- Update response times from 2-3 days to 3-5 days (volunteer capacity)
- Replace 'What We Do' with 'What We're Building'
- Reframe event schedules as 'planned programming' not scheduled events
- Streamline README to overview, point to CONTRIBUTING.md for details

Benefits of this approach:
- Builds trust through honesty about current status
- Attracts engaged founding members vs. passive consumers
- Prevents disappointment from unmet expectations
- Aligns commitments with volunteer capacity
- Positions founding membership as valuable opportunity

All pages now consistently communicate founding phase status while maintaining professional quality and enthusiasm for the vision.